### PR TITLE
Add callback for panorama loaded event

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -15,6 +15,10 @@ export default class App extends React.Component {
     );
   }
 
+  onPanoramaLoaded() {
+    console.log('Panorama loaded');
+  }
+
   render() {
     return (
       <div className="App">
@@ -29,6 +33,7 @@ export default class App extends React.Component {
             width: '100%',
             height: '90vh'
           }}
+          onPanoramaLoaded={this.onPanoramaLoaded}
         />
         <div style={{ cursor: 'pointer' }} onClick={this.onClick.bind(this)}>
           Add Hostpot

--- a/src/components/ReactPannellum.js
+++ b/src/components/ReactPannellum.js
@@ -13,7 +13,8 @@ class ReactPannellum extends React.Component {
     imageSource: PropTypes.string.isRequired,
     config: PropTypes.shape({}),
     className: PropTypes.string,
-    style: PropTypes.shape({})
+    style: PropTypes.shape({}),
+    onPanoramaLoaded: PropTypes.func
   };
 
   static defaultProps = {
@@ -77,7 +78,12 @@ class ReactPannellum extends React.Component {
   componentDidMount() {
     if (this.props.imageSource) {
       this.initPanalleum();
+      this.props.onPanoramaLoaded && myPannellum.on('load', () => this.props.onPanoramaLoaded());
     }
+  }
+
+  componentWillUnmount() {
+    myPannellum && this.props.onPanoramaLoaded && myPannellum.off('load', this.props.onPanoramaLoaded);
   }
 
   static isLoaded() {


### PR DESCRIPTION
Sometimes it's good to know when a panorama is loaded. A potential use case is that you have a panorama that is slow to load and you want to do some custom stuff while loading, like show a custom spinner.