### PR TITLE
Fix onPanoramaLoaded

### DIFF
--- a/src/components/ReactPannellum.jsx
+++ b/src/components/ReactPannellum.jsx
@@ -75,6 +75,8 @@ class ReactPannellum extends React.Component {
         },
       },
     });
+    this.props.onPanoramaLoaded &&
+      myPannellum.on("load", () => this.props.onPanoramaLoaded());
   };
 
   initPanalleum() {
@@ -122,8 +124,6 @@ class ReactPannellum extends React.Component {
 
   componentDidMount() {
     this.initPanalleum();
-    this.props.onPanoramaLoaded &&
-      myPannellum.on("load", () => this.props.onPanoramaLoaded());
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Fixes #54 by moving the load event listener to the `init` method