### PR TITLE
Remove info default panoramaConfigs

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -26,9 +26,6 @@ export const configs = {
     ignoreGPanoXMP: false,
   },
   panoramaConfigs: {
-    title: "",
-    author: "",
-    description: "",
     autoLoad: false,
     autoRotate: 0,
     autoRotateInactivityDelay: 0,


### PR DESCRIPTION
Removed author, description, and title default configs.
These are causing the `pnlm-panorama-info` div to always have `display:inline` because pannellum  counts the empty strings as present. This would leave "by" floating in the bottom corner.
![image](https://user-images.githubusercontent.com/4642741/118572396-34af8580-b735-11eb-85cf-2f16ef7de9e2.png)

There is no way to stop the div from appearing without `display:none !important` flagged css which is ugly.