### PR TITLE
Fix issue to read file with Cordova

### DIFF
--- a/src/libs/pannellum.js
+++ b/src/libs/pannellum.js
@@ -557,7 +557,11 @@ export default (function (window, document, undefined) {
      * @param {Image} image - Image to read XMP metadata from.
      */
     function parseGPanoXMP(image) {
-      var reader = new FileReader();
+      var fileReader = new FileReader();
+      var reader = fileReader.addEventListener
+        ? fileReader
+        : fileReader._realReader;
+
       reader.addEventListener("loadend", function () {
         var img = reader.result;
 


### PR DESCRIPTION
Currently, when we try to use this lib with Cordova, the image cannot be read since Cordova's FileReader does not allow the "addEventListener" method; however, we can utilize the "_realReader".

## Changes

- Use the "_realReader" from *fileReader* if we don't find the addEventListener in the previous var.