### PR TITLE
Define version ranges for peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "start": "rollup -c -w"
   },
   "peerDependencies": {
-    "postcss": "8.2.10",
+    "postcss": "^8.2.10",
     "prop-types": "^15.5.4",
-    "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react": ">=17.0.2 <=18",
+    "react-dom": ">=17.0.2 <=18"
   },
   "devDependencies": {
     "@babel/cli": "7.13.14",


### PR DESCRIPTION
Due to stricter rules for peerDependencies in newer npm versions, the hardcoded versions are breaking the build of any project deviating in version.

By allowing a broader range of versions, this issue is resolved.

fixes #94